### PR TITLE
Fix for the definition of metaclasses

### DIFF
--- a/src/Ring2-Core/RGClassStrategy.class.st
+++ b/src/Ring2-Core/RGClassStrategy.class.st
@@ -309,8 +309,11 @@ RGClassStrategy >> definitionWithSlots [
 	poolString = '' ifFalse: [
 		aStream cr; tab; nextPutAll: 'poolDictionaries: ';
 			store: poolString].
-	aStream cr; tab; nextPutAll: 'category: ';
-			store: self category asString.
+	aStream
+		cr;
+		tab;
+		nextPutAll: 'package: ';
+		store: self owner category asString.
 
 	self owner superclass ifNil: [ 
 		aStream nextPutAll: '.'; cr.

--- a/src/Ring2-Core/RGMetaclassStrategy.class.st
+++ b/src/Ring2-Core/RGMetaclassStrategy.class.st
@@ -80,12 +80,12 @@ RGMetaclassStrategy >> definition [
 
 	^ String streamContents: 
 		[:strm |
-		strm print: self.
+		strm nextPutAll: self owner name.
 		self owner hasTraitComposition ifTrue: [
 			strm
 				crtab;
 				nextPutAll: 'uses: ';
-				print: self traitComposition ].
+				nextPutAll: self owner traitCompositionString ].
 		
 		(self owner usesSpecialSlot or: [ Slot showSlotClassDefinition ])
 			ifFalse: [  

--- a/src/Ring2-Tests-Core/RGMetaclassStrategyTest.class.st
+++ b/src/Ring2-Tests-Core/RGMetaclassStrategyTest.class.st
@@ -15,6 +15,26 @@ RGMetaclassStrategyTest >> testCreationByMethod [
 ]
 
 { #category : #tests }
+RGMetaclassStrategyTest >> testDefinition [
+
+	| anRGBehavior |
+	
+	anRGBehavior := RGMetaclass named: #'SomeMetaClass class'.
+	self assert: anRGBehavior definition equals: 'SomeMetaClass class
+	instanceVariableNames: '''''.	
+]
+
+{ #category : #tests }
+RGMetaclassStrategyTest >> testDefinitionForNautilus [
+
+	| anRGBehavior |
+	
+	anRGBehavior := RGMetaclass named: #'SomeMetaClass class'.
+	self assert: anRGBehavior definitionForNautilus equals: 'SomeMetaClass class
+	instanceVariableNames: '''''.	
+]
+
+{ #category : #tests }
 RGMetaclassStrategyTest >> testIncompatibleBehavior [
 
 	| anRGBehavior aTrait |


### PR DESCRIPTION
Hello Pavel,

RGMetaclassStrategy >> #definition returned a String with an incorrect definition. This commit contains a fix and a unit test for this problem.

Jan.