### PR TITLE
Fix problem produced when classVariables is a RGUnresolvedValue

### DIFF
--- a/src/Ring2-Core/RGClassStrategy.class.st
+++ b/src/Ring2-Core/RGClassStrategy.class.st
@@ -44,7 +44,7 @@ RGClassStrategy >> allClassVariables [
 
 	^ ((self owner superclass == nil) or: [ self owner superclass == self owner]) 
 		ifTrue: [ self classVariables ]
-		ifFalse: [ self owner superclass allClassVariables, classVariables ]
+		ifFalse: [ self owner superclass allClassVariables, self classVariables ]
 ]
 
 { #category : #'private - backend access' }


### PR DESCRIPTION
Solved by using the accessor for classVariables, which returns an empty collection when classVariables is an RGUnresolvedValue